### PR TITLE
「fancybox.js」による画像拡大表示時にオーバーレイ下のコンテンツが見えなくなる問題への対応

### DIFF
--- a/js/source/jquery.fancybox.css
+++ b/js/source/jquery.fancybox.css
@@ -165,7 +165,8 @@
 /* Overlay helper */
 
 .fancybox-lock {
-    overflow: hidden !important;
+	/* @mod 20151031 T.Masuda オーバーレイ下のコンテンツが消えてしまうためコメントアウト */
+   /* overflow: hidden !important; */	
     width: auto;
 }
 


### PR DESCRIPTION
「jquery.fancybox.css」のスタイルを1個無効にしました。

自前でマージします
